### PR TITLE
Add basal dosing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import RescuePage from "./pages/RescuePage";
 import { smartMonitor } from "./lib/healthMonitor";
 import Backend from "./lib/remote/backend";
 import RemoteStorage from "./lib/remote/storage";
+import BasalPage from "./pages/BasalPage";
 
 function App() {
   const navigate = useNavigate();
@@ -68,6 +69,7 @@ function App() {
           <Route path="/dextrose" element={<DextrosePage />} />
           <Route path="/statistics" element={<StatisticsPage />} />
           <Route path="/rescue" element={<RescuePage />} />
+          <Route path="/basal" element={<BasalPage />} />
 
           {/* Wizard Routes */}
           <Route path="/wizard" element={<WizardRouterPage />} />

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -48,6 +48,9 @@ function TopBar() {
               <Nav.Link as={Link} to="/wizard" onClick={handleClose}>
                 Wizard
               </Nav.Link>
+              <Nav.Link as={Link} to="/basal" onClick={handleClose}>
+                Basal Injection
+              </Nav.Link>
               <Nav.Link as={Link} to="/customfoods" onClick={handleClose}>
                 Custom Foods
               </Nav.Link>

--- a/src/lib/basal.ts
+++ b/src/lib/basal.ts
@@ -121,7 +121,7 @@ export function markBasal(units: number) {
 
   // Add dose to the list of doses
   let doses: number[] = basalStore.get("basalDoses");
-  doses.push(units);
+  doses.splice(0, 0, units);
   basalStore.set("basalDoses", doses.slice(0, days * shotsPerDay));
 
   // Set last basal timestamp internally

--- a/src/lib/basal.ts
+++ b/src/lib/basal.ts
@@ -1,0 +1,160 @@
+import {
+  getReadingFromNightscout,
+  type SugarReading,
+} from "../models/types/sugarReading";
+import Unit from "../models/unit";
+import basalStore from "../storage/basalStore";
+import healthMonitorStore from "../storage/healthMonitorStore";
+import { getBGVelocities } from "./readingsUtil";
+import RemoteReadings from "./remote/readings";
+import RemoteTreatments, {
+  mealEventType,
+  insulinEventType,
+  glucoseEventType,
+} from "./remote/treatments";
+import { getTimestampFromOffset, timestampIsBetween } from "./timing";
+import { convertDimensions, MathUtil } from "./util";
+
+export async function isFasting(timestamp: Date) {
+  const minTimeSinceMeal = basalStore.get("minTimeSinceMeal");
+  const minTimeSinceBolus = basalStore.get("minTimeSinceBolus");
+  const minTimeSinceDextrose = basalStore.get("minTimeSinceDextrose") / 60; // Minutes -> Hours
+
+  async function isPresent(eventType: string, minTime: number) {
+    const timestampA = getTimestampFromOffset(timestamp, -minTime);
+    const treatments = await RemoteTreatments.getTreatmentByType(
+      eventType,
+      timestampA,
+      timestamp
+    );
+    return treatments.length !== 0;
+  }
+  if (await isPresent(mealEventType, minTimeSinceMeal)) return false;
+  if (await isPresent(insulinEventType, minTimeSinceBolus)) return false;
+  if (await isPresent(glucoseEventType, minTimeSinceDextrose)) return false;
+  return true;
+}
+
+function getFastingVelocities(
+  treatments: any[],
+  readings: SugarReading[]
+): number[] {
+  const minTimeSinceMeal = basalStore.get("minTimeSinceMeal");
+  const minTimeSinceBolus = basalStore.get("minTimeSinceBolus");
+  const minTimeSinceDextrose = basalStore.get("minTimeSinceDextrose") / 60; // Minutes -> Hours
+
+  let nonFasting: [Date, Date][] = []; // A set of date pairs to describe when we are not fasting
+  treatments.forEach((a: any) => {
+    let hoursNonFasting: number | null = null;
+    if (a.insulin) hoursNonFasting = minTimeSinceBolus;
+    switch (a.eventType) {
+      case mealEventType:
+        hoursNonFasting = minTimeSinceMeal;
+        break;
+      case insulinEventType:
+        hoursNonFasting = minTimeSinceBolus;
+        break;
+      case glucoseEventType:
+        hoursNonFasting = minTimeSinceDextrose;
+        break;
+    }
+    if (hoursNonFasting !== null)
+      nonFasting.push([
+        a.timestamp,
+        getTimestampFromOffset(a.timestamp, hoursNonFasting),
+      ]);
+  });
+
+  let velocities: number[] = [];
+  const isFasting = (timestamp: Date): boolean => {
+    for (let datePair of nonFasting) {
+      const timestampA = datePair[0];
+      const timestampB = datePair[1];
+      if (timestampIsBetween(timestamp, timestampA, timestampB)) return false;
+    }
+    return true;
+  };
+  let currentSet: SugarReading[] = [];
+  readings.forEach((reading: SugarReading, index: number) => {
+    const fasting = isFasting(reading.timestamp);
+    if (fasting) {
+      currentSet.push(reading);
+    }
+    if (!fasting || index === readings.length - 1) {
+      if (currentSet.length > 1) {
+        const setVelocities = getBGVelocities(currentSet);
+        if (setVelocities) velocities.push(...setVelocities);
+      }
+      currentSet = [];
+    }
+  });
+  return velocities;
+}
+
+export async function populateFastingVelocitiesCache() {
+  const days = basalStore.get("basalEffectDays");
+  const hours = days * convertDimensions(Unit.Time.Day, Unit.Time.Hour);
+  const now = new Date();
+  const timestampA = getTimestampFromOffset(now, -hours);
+  const timestampB = now;
+  const treatments: any[] = await RemoteTreatments.getTreatments(
+    timestampA,
+    now
+  );
+  const rawReadings = await RemoteReadings.getReadings(timestampA, timestampB);
+  const readings = rawReadings.map((a: any) => getReadingFromNightscout(a));
+  basalStore.set(
+    "fastingVelocitiesCache",
+    getFastingVelocities(treatments, readings)
+  );
+}
+
+export function getFastingVelocity() {
+  const fastingVelocities = basalStore.get("fastingVelocitiesCache");
+  const averageVelocities = MathUtil.mean(fastingVelocities);
+  return averageVelocities;
+}
+
+export function markBasal(units: number) {
+  const days = basalStore.get("basalEffectDays");
+  const shotsPerDay = healthMonitorStore.get("basalShotsPerDay");
+
+  // Add dose to the list of doses
+  let doses: number[] = basalStore.get("basalDoses");
+  doses.push(units);
+  basalStore.set("basalDoses", doses.slice(0, days * shotsPerDay));
+
+  // Set last basal timestamp internally
+  const timestamp = new Date();
+  basalStore.set("lastBasalTimestamp", timestamp);
+
+  // Mark in nightscout
+  RemoteTreatments.markBasal(units, timestamp);
+}
+
+export function getBasals() {
+  return basalStore.get("basalDoses") as number[];
+}
+export function getLastBasalTimestamp() {
+  return basalStore.get("lastBasalTimestamp") as Date;
+}
+
+export function getDailyBasal() {
+  const doses: number[] = basalStore.get("basalDoses");
+  const shotsPerDay = healthMonitorStore.get("basalShotsPerDay");
+  let sum = 0;
+  let days = 0;
+  for (let i = 0; i + shotsPerDay <= doses.length; i += shotsPerDay) {
+    let totalDose = 0;
+    for (let j = i; j < i + shotsPerDay; j++) {
+      totalDose += doses[j];
+    }
+    sum += totalDose;
+    days++;
+  }
+  return sum / days;
+}
+export function getDailyBasalPerShot() {
+  const shotsPerDay = healthMonitorStore.get("basalShotsPerDay");
+  return getDailyBasal() / shotsPerDay;
+}

--- a/src/lib/healthMonitor.ts
+++ b/src/lib/healthMonitor.ts
@@ -28,6 +28,8 @@ import { getHourDiff, getMinuteDiff } from "./timing";
 import { MathUtil, round } from "./util";
 import RemoteReadings from "./remote/readings";
 import { getBGVelocities } from "./readingsUtil";
+import basalStore from "../storage/basalStore";
+import { populateFastingVelocitiesCache } from "./basal";
 
 export let healthMonitorStatus = HealthMonitorStatus.Nominal;
 
@@ -94,8 +96,50 @@ export function getLastRescueCaps() {
   return getLastRescue().caps;
 }
 
+// Basal
+export function getTimeSinceLastBasal() {
+  const lastBasalTimestamp = basalStore.get("lastBasalTimestamp");
+  return getHourDiff(new Date(), lastBasalTimestamp);
+}
+export function basalIsDue() {
+  const shotsPerDay = healthMonitorStore.get("basalShotsPerDay");
+  const interval = 24 / shotsPerDay;
+  const timeSinceLastBasal = getTimeSinceLastBasal();
+
+  // Rule 1: If it's been too long since last shot
+  if (timeSinceLastBasal >= interval) {
+    return true;
+  }
+
+  // We infer the following times being equally spaced. For example, if two shots, our first shot is at 8, and the second is at 20. If three shots, it's 8, 16, 24
+
+  // If it's been longer than the allowed interval since the last basal, or if the current time has passed the scheduled basal shot time and the shot hasn't been taken yet, basal is due
+  // Rule 2: Based on scheduled times
+  const firstShotHour = healthMonitorStore.get("basalShotTime"); // 8 => 8:00 AM, 16 => 4:00 PM
+  const now = new Date();
+  const nowTime = now.getTime();
+  const lastBasal = basalStore.get("lastBasalTimestamp");
+
+  // Get the current hour we are targetting
+  for (let i = 0; i < shotsPerDay; i++) {
+    const hour = firstShotHour + i * interval; // Scheduled hour. We consider yesterday as well
+    const scheduledTimestamp = new Date();
+    scheduledTimestamp.setHours(hour % 24, 0, 0, 0);
+
+    if (hour >= 24)
+      scheduledTimestamp.setDate(scheduledTimestamp.getDate() + 1);
+    if (scheduledTimestamp.getTime() <= nowTime) {
+      if (lastBasal.getTime() < scheduledTimestamp.getTime()) return true;
+      continue;
+    }
+  }
+
+  return false;
+}
+
 export async function updateHealthMonitorStatus() {
   const readings: SugarReading[] | null = await populateReadingCache();
+  populateFastingVelocitiesCache();
   if (readings) {
     // Assume things are nominal
     healthMonitorStatus = HealthMonitorStatus.Nominal;
@@ -118,6 +162,12 @@ export async function updateHealthMonitorStatus() {
       return healthMonitorStatus;
     }
 
+    // If we need to take basal insulin
+    if (basalIsDue()) {
+      healthMonitorStatus = HealthMonitorStatus.Basal;
+      return healthMonitorStatus;
+    }
+
     // Final return
     return HealthMonitorStatus.Nominal;
   }
@@ -135,6 +185,9 @@ export async function smartMonitor(navigate: NavigateFunction) {
         break;
       case HealthMonitorStatus.High:
         navigate("/wizard");
+        break;
+      case HealthMonitorStatus.Basal:
+        navigate("/basal");
         break;
       default:
         break;

--- a/src/lib/healthMonitor.ts
+++ b/src/lib/healthMonitor.ts
@@ -27,6 +27,7 @@ import preferencesStore from "../storage/preferencesStore";
 import { getHourDiff, getMinuteDiff } from "./timing";
 import { MathUtil, round } from "./util";
 import RemoteReadings from "./remote/readings";
+import { getBGVelocities } from "./readingsUtil";
 
 export let healthMonitorStatus = HealthMonitorStatus.Nominal;
 
@@ -47,10 +48,10 @@ export async function populateReadingCache() {
 
 /** Get readings */
 function getReadings() {
-  return healthMonitorStore.get("readingsCache");
+  return healthMonitorStore.get("readingsCache") as SugarReading[];
 }
 export function getCurrentBG() {
-  return healthMonitorStore.get("currentBG");
+  return healthMonitorStore.get("currentBG") as number;
 }
 
 /** This function returns (mg/dL) / hr.
@@ -58,20 +59,7 @@ export function getCurrentBG() {
  */
 export function getBGVelocity() {
   const readings = getReadings();
-  let velocities = [];
-  if (readings.length < 2) {
-    return 0;
-  }
-  for (let i = 0; i < readings.length - 1; i++) {
-    const currentReading = readings[i];
-    const lastReading = readings[i + 1];
-    const timeDiff = getHourDiff(
-      currentReading.timestamp,
-      lastReading.timestamp
-    );
-    const velocity = (currentReading.sugar - lastReading.sugar) / timeDiff;
-    velocities.push(velocity);
-  }
+  const velocities = getBGVelocities(readings);
   // We give the median of all the velocities to rule out insane jumps
   return MathUtil.median(velocities);
 }

--- a/src/lib/metabolism.ts
+++ b/src/lib/metabolism.ts
@@ -2,6 +2,7 @@ import type Session from "../models/session";
 import Insulin from "../models/events/insulin";
 import { profile } from "../storage/metaProfileStore";
 import { getTimestampFromOffset } from "./timing";
+import basalStore from "../storage/basalStore";
 
 // Insulin
 export function getInsulin(carbs: number, protein: number) {
@@ -196,4 +197,13 @@ export function getIntelligentGlucoseCorrection(
   const velocityMinutes = velocityHours / 60;
   const predictedDrop = velocityMinutes * actingMinutes;
   return getGlucoseCorrectionCaps(currentBG + predictedDrop); // We add predictedDrop because if the sugar is dropping, the velocity will be negative (along with predictedDrop being negative too)
+}
+
+// Basal
+/**
+ * velocity: (mg/dL) / hr
+ */
+export function getBasalCorrection(velocity: number): number {
+  const basalVelocityEffect = basalStore.get("basalEffect"); // [(mg/dL) per hour] / unit
+  return velocity / basalVelocityEffect;
 }

--- a/src/lib/readingsUtil.ts
+++ b/src/lib/readingsUtil.ts
@@ -1,0 +1,23 @@
+import type { SugarReading } from "../models/types/sugarReading";
+import { getHourDiff } from "./timing";
+
+/** This function returns (mg/dL) / hr.
+ * It describes how quickly blood sugar is moving based on the readings
+ */
+export function getBGVelocities(readings: SugarReading[]): number[] {
+  let velocities = [];
+  if (readings.length < 2) {
+    return [];
+  }
+  for (let i = 0; i < readings.length - 1; i++) {
+    const currentReading = readings[i];
+    const lastReading = readings[i + 1];
+    const timeDiff = getHourDiff(
+      currentReading.timestamp,
+      lastReading.timestamp
+    );
+    const velocity = (currentReading.sugar - lastReading.sugar) / timeDiff;
+    velocities.push(velocity);
+  }
+  return velocities;
+}

--- a/src/lib/remote/treatments.ts
+++ b/src/lib/remote/treatments.ts
@@ -1,9 +1,32 @@
 import { round } from "../util";
 import Backend from "./backend";
 
+export const insulinEventType = "Meal Bolus";
 export const basalEventType = "Basal Insulin";
+export const mealEventType = "Meal";
+export const glucoseEventType = "Carb Correction";
 
 class RemoteTreatments {
+  static async getTreatments(timestampA: Date, timestampB: Date) {
+    return await Backend.get(
+      `treatments.json?find[created_at][$gte]=${timestampA.toString()}&find[created_at][$lte]=${timestampB.toString()}`
+    ).then((a: any[]) => {
+      return a.map((b: any) => {
+        b.timestamp = new Date(b.created_at);
+        return b;
+      });
+    });
+  }
+  static async getTreatmentByType(
+    eventType: string,
+    timestampA: Date,
+    timestampB: Date
+  ) {
+    const urlSafeEventType = eventType.replace(/ /g, "+");
+    return await Backend.get(
+      `treatments.json?&find[eventType]=${urlSafeEventType}&find[created_at][$gte]=${timestampA.toString()}&find[created_at][$lte]=${timestampB.toString()}`
+    );
+  }
   static markMeal(_carbs: number, _protein: number, timestamp: Date): void {
     const carbs = round(_carbs, 1);
     const protein = round(_protein, 1);

--- a/src/lib/remote/treatments.ts
+++ b/src/lib/remote/treatments.ts
@@ -1,9 +1,7 @@
 import { round } from "../util";
 import Backend from "./backend";
 
-const insulinEventType = "Meal Bolus";
-const mealEventType = "Meal";
-const glucoseEventType = "Carb Correction";
+export const basalEventType = "Basal Insulin";
 
 class RemoteTreatments {
   static markMeal(_carbs: number, _protein: number, timestamp: Date): void {
@@ -26,6 +24,16 @@ class RemoteTreatments {
       {
         insulin: units,
         eventType: insulinEventType,
+      },
+      timestamp
+    );
+  }
+  static markBasal(units: number, timestamp: Date): void {
+    Backend.post(
+      "treatments",
+      {
+        insulin: units,
+        eventType: basalEventType,
       },
       timestamp
     );

--- a/src/lib/timing.ts
+++ b/src/lib/timing.ts
@@ -18,6 +18,19 @@ export function getHourDiff(timestampA: Date, timestampB: Date): number {
 export function getMinuteDiff(timestampA: Date, timestampB: Date): number {
   return getEpochMinutes(timestampA) - getEpochMinutes(timestampB);
 }
+export function timestampIsBetween(
+  timestamp: Date,
+  timestampA: Date,
+  timestampB: Date
+) {
+  const timestampEpoch = timestamp.getTime();
+  if (
+    timestampEpoch <= timestampB.getTime() &&
+    timestampEpoch >= timestampA.getTime()
+  )
+    return true;
+  return false;
+}
 
 export function getTimestampFromOffset(timestamp: Date, hours: number): Date {
   const unixTimestamp = timestamp.getTime();

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -31,14 +31,16 @@ export function getHoursMinutes(_min: number) {
 
 // Statistics
 export class MathUtil {
-  static mean(data: number[]): number {
+  static sum(data: number[]): number {
     if (data.length === 0) return 0;
     let retval = 0;
     data.forEach((a) => {
       retval += a;
     });
-    retval = retval / data.length;
     return retval;
+  }
+  static mean(data: number[]): number {
+    return this.sum(data) / data.length;
   }
   static median(data: number[]): number {
     if (data.length === 0) return 0;

--- a/src/models/types/healthMonitorStatus.ts
+++ b/src/models/types/healthMonitorStatus.ts
@@ -3,6 +3,7 @@ enum HealthMonitorStatus {
   Low,
   Falling,
   High,
+  Basal,
 }
 export default HealthMonitorStatus;
 
@@ -12,6 +13,7 @@ const statusNames: StatusNameKey[] = [
   [HealthMonitorStatus.Low, "low"],
   [HealthMonitorStatus.Falling, "falling"],
   [HealthMonitorStatus.High, "high"],
+  [HealthMonitorStatus.Basal, "basal"],
 ];
 
 // Serialization

--- a/src/pages/BasalPage.tsx
+++ b/src/pages/BasalPage.tsx
@@ -1,9 +1,11 @@
 import { Button, Form, InputGroup } from "react-bootstrap";
 import Card from "../components/Card";
 import {
+  dosingChangeComplete,
   getBasals,
   getFastingVelocity,
   getLastBasalTimestamp,
+  getRecommendedBasal,
   markBasal,
 } from "../lib/basal";
 import { getBasalCorrection } from "../lib/metabolism";
@@ -21,7 +23,8 @@ export default function BasalPage() {
   const basals = getBasals();
   const lastBasalTimestamp = getLastBasalTimestamp();
 
-  const suggestedBasal = basals[shotsPerDay - 1] || 0;
+  const suggestedBasal = getRecommendedBasal();
+  const changeIsComplete = dosingChangeComplete();
   const [basalDose, setBasalDose] = useState(0);
 
   const navigate = useNavigate();
@@ -79,15 +82,22 @@ export default function BasalPage() {
         {getHoursSince(lastBasalTimestamp)} hours ago
       </Card>
       <Card>
-        You fasting glucose rise rate is {round(fastingVelocity, 0)}mg/dL per
-        hour
+        You fasting glucose rise rate is around {round(fastingVelocity, 0)}mg/dL
+        per hour
         <br />
         {Math.abs(basalCorrection) > 0.5 && (
           <>
-            Consider raising the dosage by <b>{basalCorrection}u per day</b>{" "}
-            <i>{shotsPerDay > 1 && `(${basalCorrectionPerDay}u per shot)`}</i>
+            Consider raising the dosage to <b>{suggestedBasal}u per shot</b>{" "}
+            <i>
+              {shotsPerDay > 1 &&
+                `(${basalCorrectionPerDay}u increase per shot)`}
+            </i>
           </>
         )}
+        <hr />
+        {changeIsComplete
+          ? `Your current dosing cycle is complete`
+          : `Your current dosing cycle is not complete`}
       </Card>
       <Card>
         <InputGroup className="mb-3">

--- a/src/pages/BasalPage.tsx
+++ b/src/pages/BasalPage.tsx
@@ -1,0 +1,114 @@
+import { Button, Form, InputGroup } from "react-bootstrap";
+import Card from "../components/Card";
+import {
+  getBasals,
+  getFastingVelocity,
+  getLastBasalTimestamp,
+  markBasal,
+} from "../lib/basal";
+import { getBasalCorrection } from "../lib/metabolism";
+import { round } from "../lib/util";
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { getHourDiff, getPrettyTime } from "../lib/timing";
+import healthMonitorStore from "../storage/healthMonitorStore";
+
+export default function BasalPage() {
+  const fastingVelocity = getFastingVelocity();
+  const basalCorrection = round(getBasalCorrection(fastingVelocity), 0);
+  const shotsPerDay = healthMonitorStore.get("basalShotsPerDay");
+  const basalCorrectionPerDay = round(basalCorrection / shotsPerDay, 1);
+  const basals = getBasals();
+  const lastBasalTimestamp = getLastBasalTimestamp();
+
+  const suggestedBasal = basals[basals.length - shotsPerDay] || 0;
+  const [basalDose, setBasalDose] = useState(suggestedBasal);
+
+  const navigate = useNavigate();
+  function markBasalInjection() {
+    markBasal(basalDose);
+    navigate("/");
+  }
+
+  const firstShotHour = healthMonitorStore.get("basalShotTime"); // 8 => 8:00 AM, 16 => 4:00 PM
+  const interval = 24 / shotsPerDay;
+  function getTimes() {
+    let strings: string[] = [];
+    for (let i = 0; i < shotsPerDay; i++) {
+      const hour = firstShotHour + i * interval;
+      const suffix = hour < 12 ? "AM" : "PM";
+      strings.push(`${hour % 12}:00 ${suffix}`);
+    }
+    return strings;
+  }
+
+  function getHoursSince(timestamp: Date) {
+    return round(getHourDiff(new Date(), timestamp), 0);
+  }
+
+  return (
+    <>
+      <Card>
+        You take {shotsPerDay} basal injection(s) per day at:
+        <br />
+        {getTimes().map((s: string) => {
+          return (
+            <>
+              {s}
+              <br />
+            </>
+          );
+        })}
+        <hr />
+        Previous Doses:
+        <br />
+        <b>
+          {basals.map((a: number) => {
+            return (
+              <>
+                {a}u<br />
+              </>
+            );
+          })}
+        </b>
+        <hr />
+        Last dose taken at {getPrettyTime(lastBasalTimestamp)},{" "}
+        {getHoursSince(lastBasalTimestamp)} hours ago
+      </Card>
+      <Card>
+        You fasting glucose rise rate is {round(fastingVelocity, 0)}mg/dL per
+        hour
+        <br />
+        {Math.abs(basalCorrection) > 0.5 && (
+          <>
+            Consider raising the dosage by <b>{basalCorrection}u per day</b>{" "}
+            <i>{shotsPerDay > 1 && `(${basalCorrectionPerDay}u per shot)`}</i>
+          </>
+        )}
+      </Card>
+      <Card>
+        <InputGroup className="mb-3">
+          <InputGroup.Text id="basic-addon1">
+            <i className="bi bi-eyedropper"></i>
+          </InputGroup.Text>
+          <Form.Control
+            placeholder={`${suggestedBasal.toString()}`}
+            aria-label="URL"
+            aria-describedby="basic-addon1"
+            onChange={(e: any) => {
+              const val = parseFloat(e.target.value);
+              if (!isNaN(val)) setBasalDose(val);
+              else setBasalDose(0);
+            }}
+          />
+          <InputGroup.Text id="basic-addon1">u</InputGroup.Text>
+        </InputGroup>
+      </Card>
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <Button variant="primary" onClick={markBasalInjection}>
+          Mark Basal
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/src/pages/BasalPage.tsx
+++ b/src/pages/BasalPage.tsx
@@ -43,8 +43,8 @@ export default function BasalPage() {
     let strings: string[] = [];
     for (let i = 0; i < shotsPerDay; i++) {
       const hour = firstShotHour + i * interval;
-      const suffix = hour < 12 ? "AM" : "PM";
-      strings.push(`${hour % 12}:00 ${suffix}`);
+      const suffix = hour < 12 || hour === 24 ? "AM" : "PM";
+      strings.push(`${hour % 12 || 12}:00 ${suffix}`);
     }
     return strings;
   }

--- a/src/pages/BasalPage.tsx
+++ b/src/pages/BasalPage.tsx
@@ -82,15 +82,20 @@ export default function BasalPage() {
         {getHoursSince(lastBasalTimestamp)} hours ago
       </Card>
       <Card>
-        You fasting glucose rise rate is around {round(fastingVelocity, 0)}mg/dL
-        per hour
+        You fasting blood glucose rate is around{" "}
+        <b>
+          {fastingVelocity > 0 && "+"}
+          {round(fastingVelocity, 0)}mg/dL per hour
+        </b>
         <br />
         {Math.abs(basalCorrection) > 0.5 && (
           <>
-            Consider raising the dosage to <b>{suggestedBasal}u per shot</b>{" "}
+            Consider adjusting dosage to <b>{suggestedBasal}u per shot</b>{" "}
             <i>
               {shotsPerDay > 1 &&
-                `(${basalCorrectionPerDay}u increase per shot)`}
+                `(${
+                  basalCorrectionPerDay > 0 ? "+" : ""
+                }${basalCorrectionPerDay}u per shot)`}
             </i>
           </>
         )}

--- a/src/pages/BasalPage.tsx
+++ b/src/pages/BasalPage.tsx
@@ -22,12 +22,16 @@ export default function BasalPage() {
   const lastBasalTimestamp = getLastBasalTimestamp();
 
   const suggestedBasal = basals[basals.length - shotsPerDay] || 0;
-  const [basalDose, setBasalDose] = useState(suggestedBasal);
+  const [basalDose, setBasalDose] = useState(0);
 
   const navigate = useNavigate();
   function markBasalInjection() {
-    markBasal(basalDose);
-    navigate("/");
+    if (
+      confirm(`Confirm that you have injected ${basalDose}u of basal insulin`)
+    ) {
+      markBasal(basalDose);
+      navigate("/");
+    }
   }
 
   const firstShotHour = healthMonitorStore.get("basalShotTime"); // 8 => 8:00 AM, 16 => 4:00 PM

--- a/src/pages/BasalPage.tsx
+++ b/src/pages/BasalPage.tsx
@@ -21,7 +21,7 @@ export default function BasalPage() {
   const basals = getBasals();
   const lastBasalTimestamp = getLastBasalTimestamp();
 
-  const suggestedBasal = basals[basals.length - shotsPerDay] || 0;
+  const suggestedBasal = basals[shotsPerDay - 1] || 0;
   const [basalDose, setBasalDose] = useState(0);
 
   const navigate = useNavigate();
@@ -64,17 +64,16 @@ export default function BasalPage() {
           );
         })}
         <hr />
-        Previous Doses:
+        Previous doses (newest first):
         <br />
-        <b>
-          {basals.map((a: number) => {
-            return (
-              <>
-                {a}u<br />
-              </>
-            );
-          })}
-        </b>
+        {basals.map((a: number, i: number) => {
+          return (
+            <>
+              <b>{a}u</b> {i === 0 && `(${getPrettyTime(lastBasalTimestamp)})`}
+              <br />
+            </>
+          );
+        })}
         <hr />
         Last dose taken at {getPrettyTime(lastBasalTimestamp)},{" "}
         {getHoursSince(lastBasalTimestamp)} hours ago

--- a/src/pages/HubPage.tsx
+++ b/src/pages/HubPage.tsx
@@ -71,11 +71,7 @@ function HubPage() {
                       Build and interact with meals easily using our session
                       wizard.
                     </Card.Text>
-                    <Button
-                      variant="primary"
-                      as={Link as any}
-                      to="/template/select"
-                    >
+                    <Button variant="primary" as={Link as any} to="/wizard">
                       Get Started
                     </Button>
                   </>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -179,6 +179,20 @@ export default function SettingsPage() {
       </Card>
       <Card>
         <NumberSetting
+          node={healthMonitorStore}
+          id={"basalShotsPerDay"}
+          title="Basal Injections Per Day"
+          iconClass="bi bi-capsule"
+          unit="shots"
+        />
+        <NumberSetting
+          node={healthMonitorStore}
+          id={"basalShotTime"}
+          title="Basal Injection First Hour"
+          iconClass="bi bi-clock"
+          unit=""
+        />
+        <NumberSetting
           node={basalStore}
           id={"basalEffect"}
           title="Basal Insulin Effect (per unit)"

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import type StorageNode from "../lib/storageNode";
 import { useState } from "react";
 import RemoteStorage from "../lib/remote/storage";
 import privateStore from "../storage/privateStore";
+import basalStore from "../storage/basalStore";
 
 interface Setting {
   title: string;
@@ -174,6 +175,15 @@ export default function SettingsPage() {
           title="CGM Delay (in minutes)"
           iconClass="bi bi-clock"
           unit="min"
+        />
+      </Card>
+      <Card>
+        <NumberSetting
+          node={basalStore}
+          id={"basalEffect"}
+          title="Basal Insulin Effect (per unit)"
+          iconClass="bi bi-eyedropper"
+          unit="mg/dL per hr"
         />
       </Card>
     </>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -37,9 +37,11 @@ function NumberSetting({ title, node, id, iconClass, unit }: Setting) {
           value={value}
           aria-describedby="basic-addon1"
           onChange={(a) => {
-            const v = a.target.value;
-            node.set(id, v);
-            setValue(v);
+            const v = parseFloat(a.target.value);
+            if (!Number.isNaN(v)) {
+              node.set(id, v);
+              setValue(v);
+            }
           }}
         />
         <InputGroup.Text>{unit}</InputGroup.Text>

--- a/src/storage/basalStore.ts
+++ b/src/storage/basalStore.ts
@@ -21,3 +21,7 @@ basalStore.add("minTimeSinceDextrose", 30); // Minutes
 
 basalStore.add("basalEffect", 1.5); // Rate effect (mg/dL) per hour of 1 unit of basal insulin
 basalStore.add("basalEffectDays", 3); // Days basal stays in system
+
+// Changes logic
+basalStore.add("lastRecommendation", []);
+basalStore.add("shotsSinceLastChange", 0);

--- a/src/storage/basalStore.ts
+++ b/src/storage/basalStore.ts
@@ -1,0 +1,23 @@
+import StorageNode from "../lib/storageNode";
+
+const basalStore = new StorageNode("basal");
+export default basalStore;
+
+basalStore.add("basalDoses", []);
+basalStore.add(
+  "lastBasalTimestamp",
+  new Date(""),
+  (a: string) => new Date(a),
+  (d: Date) => d.toString()
+);
+
+basalStore.add("fastingVelocitiesCache", []);
+basalStore.add("fastingVelocitiesCacheLastUpdated", new Date(""));
+
+// Fasting state qualifiers
+basalStore.add("minTimeSinceMeal", 5.5); // Hours
+basalStore.add("minTimeSinceBolus", 7); // Hours
+basalStore.add("minTimeSinceDextrose", 30); // Minutes
+
+basalStore.add("basalEffect", 1.5); // Rate effect (mg/dL) per hour of 1 unit of basal insulin
+basalStore.add("basalEffectDays", 3); // Days basal stays in system

--- a/src/storage/healthMonitorStore.ts
+++ b/src/storage/healthMonitorStore.ts
@@ -28,3 +28,6 @@ healthMonitorStore.add(
 healthMonitorStore.add("currentBG", 83);
 healthMonitorStore.add("timeBetweenShots", 15);
 healthMonitorStore.add("dropTime", 20);
+
+healthMonitorStore.add("basalShotsPerDay", 1);
+healthMonitorStore.add("basalShotTime", 8); // The hour time we take our first shot of the day. E.g. 8 => 8:00 AM, 16 => 4:00 PM


### PR DESCRIPTION
This pull request introduces full support for basal insulin management within SynthIQ, completing a major milestone in automating routine diabetes treatment. The basal system is built to require minimal user effort while delivering robust analysis of long-acting insulin effectiveness based purely on observed data.

At the core of this feature is a logging system that allows users to record basal doses with timestamps, synced locally and to Nightscout. Dosing history is maintained to support both average daily and per-shot calculations, providing a clear picture of long-term patterns. The app also tracks scheduled basal injections based on a configurable first dose time and number of daily shots, and it intelligently determines when a dose is due based on elapsed time or missed windows.

To evaluate whether a user’s basal insulin is properly tuned, the system passively monitors CGM data under fasting conditions. It excludes glucose readings influenced by recent meals, bolus insulin, or corrections. Through velocity analysis, it calculates how blood sugar behaves in a truly basal-driven state. Mean velocity is used to mitigate the effects of CGM noise while capturing subtle trends. Based on this data, SynthIQ determines whether basal insulin is too strong, too weak, or appropriately balanced, and it provides concrete unit-based adjustment recommendations.

This feature integrates directly with SynthIQ’s Health Monitor system, which acts as a passive watchdog. When fasting trends indicate that basal insulin may be misaligned, the app proactively notifies the user with a recommended course of action. As with the rest of the app’s design, this is meant to relieve mental load by converting long-term observation into clear, reliable feedback. With this release, SynthIQ closes one of the final gaps in its automation loop, offering end-to-end support for basal, bolus, correction, and glucose rescue with minimal user overhead.